### PR TITLE
Fix showing wrong arrow in Panel label

### DIFF
--- a/modules/disk.js
+++ b/modules/disk.js
@@ -149,11 +149,11 @@ PanelLabel.prototype = {
     },
 
     write: function(){
-        return this.formatRate(this.data.write);
+        return this.formatRate(this.data.write, true);
     },
 
     read: function(){
-        return this.formatRate(this.data.read);
+        return this.formatRate(this.data.read, false);
     }
 };
 

--- a/modules/network.js
+++ b/modules/network.js
@@ -117,14 +117,14 @@ PanelLabel.prototype = {
 
     up: function(format){
         if(format === "rate")
-            return this.formatRate(this.data.up);
+            return this.formatRate(this.data.up, true);
 
         return this.formatBytes(this.raw.up);
     },
 
     down: function(format){
         if(format === "rate")
-            return this.formatRate(this.data.down);
+            return this.formatRate(this.data.down, false);
 
         return this.formatBytes(this.raw.down);
     }


### PR DESCRIPTION
I found that the network rate or disk rate would always show down-arrow.
It's because of missing dir when call formatRate in PanelLabel